### PR TITLE
added ability to show private properties with a configuration setting

### DIFF
--- a/ref.css
+++ b/ref.css
@@ -396,6 +396,10 @@
   background: #edd078;
 }
 
+.ref [data-mod-private]{
+  background: #ed7878;
+}
+
 .ref [data-mod-iterateable]{
   background: #d5dea5;
 }


### PR DESCRIPTION
I love this project! I look at a var_dump() of something or other on a daily basis, and the output from ref is so much nicer. However, var_dump() displays private properties and many times this is where the important information I'm looking for lives. So I added the option to show private properties to ref. It's off by default.

ref::config('showPrivateProperties', true);
