### PR TITLE
z-index tooltip

### DIFF
--- a/ref.css
+++ b/ref.css
@@ -70,7 +70,7 @@
 #rTip{
   display: none;  
   position: absolute;
-  z-index: 101;  
+  z-index: 99999;  
   font-size: 12px;
   white-space: pre;  
   text-align: left;  


### PR DESCRIPTION
Setting a larger value on z-index for the tooltip since on many sites it will show underneath elements when inline debugging.
