### PR TITLE
Added backtrace information

### DIFF
--- a/ref.php
+++ b/ref.php
@@ -1843,6 +1843,13 @@ class ref{
 
     if($expression === null)
       return;
+    
+    // Add information where this function was called, so the debugging
+    // person can easily find the function call
+    $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+   	if (isset($backtrace[2])) {
+   		$expression .= ' - '.$backtrace[2]['file'].'('.$backtrace[2]['line'].')';
+   	}
 
     if(static::strLen($expression) > 120)
       $expression = substr($expression, 0, 120) . '...';


### PR DESCRIPTION
In each Debug header<b data-input="">...</b> is the filename and linenumber of the calling file shown.
Example:

<b data-input=""><i>&gt; </i><b data-exptxt="">array($value, $boundary, $a, $b) - /home/.../lib/gradelib.php(783)</b></b>