### PR TITLE
prevent long strings from breaking the page layout

### DIFF
--- a/ref.css
+++ b/ref.css
@@ -1,4 +1,3 @@
-
 .ref{
   font: normal normal 12px/18px Consolas, Monaco, Andale Mono, Courier New, monospace;  
   color: #333;
@@ -300,6 +299,16 @@
   background: #e8f0e1;
   color: #669933;  
   padding: 3px 1px;
+  
+  /* prevent long strings from breaking the page layout */
+	white-space: -moz-pre-wrap; /* Mozilla */
+	white-space: -hp-pre-wrap; /* HP printers */
+	white-space: -o-pre-wrap; /* Opera 7 */
+	white-space: -pre-wrap; /* Opera 4-6 */
+	white-space: pre-wrap; /* CSS 2.1 */
+	white-space: pre-line; /* CSS 3 (and 2.1 as well, actually) */
+	word-wrap: break-word; /* IE */
+	word-break: break-all;
 }
 
 .ref [data-string][data-special]{


### PR DESCRIPTION
to see this working, r() a long string. it will break the page layout
this fix will wrap it nicely