### PR TITLE
Update ref.php

### DIFF
--- a/ref.php
+++ b/ref.php
@@ -2023,14 +2023,16 @@ class ref{
 
           if($optional){
             $paramValue = $parameter->isDefaultValueAvailable() ? $parameter->getDefaultValue() : null;            
-            $this->fmt->sep(' = ');
+            if ($paramValue !== null) {
+                $this->fmt->sep(' = ');
 
-            if(static::$env['is546'] && !$parameter->getDeclaringFunction()->isInternal() && $parameter->isDefaultValueConstant()){
-              $this->fmt->text('constant', $parameter->getDefaultValueConstantName(), 'Constant');
+                if(static::$env['is546'] && !$parameter->getDeclaringFunction()->isInternal() && $parameter->isDefaultValueConstant()){
+                  $this->fmt->text('constant', $parameter->getDefaultValueConstantName(), 'Constant');
 
-            }else{
-              $this->evaluate($paramValue, true);
-            }  
+                }else{
+                  $this->evaluate($paramValue, true);
+                }
+            }
           }
 
           $this->fmt->endContain();


### PR DESCRIPTION
In really rare cases, in the line 2025 when $paramValue results null the subsequent statements will fail with an Exception (EXCEPTION => Internal error: Failed to retrieve the default value). The solution is to check if $paramValue is null or not before trying to use $paramValue.