### PR TITLE
Added 'debugInfo' flag to switch output between Magic Method '__debugInfo()' or Default Class Structure

### DIFF
--- a/ref.php
+++ b/ref.php
@@ -143,6 +143,10 @@ class ref{
                 // note: seriously slows down queries on large amounts of data
                 'showStringMatches'    => true,
 
+                // when a class has the Magic Method "__debugInfo()" defined, show its output by default, or
+                // tet this flag to false to process the class as a normal object without the Magic Method interference
+                'debugInfo'            => true,
+
                 // shortcut functions used to access the query method below;
                 // if they are namespaced, the namespace must be present as well (methods are not supported)
                 'shortcutFunc'         => array('r', 'rt'),
@@ -1669,7 +1673,7 @@ class ref{
 
     $props = $magicProps = $methods = array();    
 
-    if($reflector->hasMethod('__debugInfo')){
+    if($reflector->hasMethod('__debugInfo') && static::$config['debugInfo']){
       $magicProps = $subject->__debugInfo();
     }else{
       $props = $reflector->getProperties($flags);


### PR DESCRIPTION
I use this debug tool quite often and, in some cases, I am required to visualize the Class structure as it is defined instead of the output of the Magic Method `__debugInfo()` (when it is present).

Due to the fact this fantastic product is meant for debugging purposes, I felt a little orphan when I realized the function evolved to arbitrarily display the output of the `__debugInfo()` without any option for me to switch it back to display the Class structure as it is defined.

With the addition of the flag "**debugInfo**" (default to _**true**_), now it possible to use the same tool for both purposes, easily switching from one output to another simply by changing the configuration on the fly:

- Default Output (using `__debugInfo()` output, if present): `ref::config('debugInfo', true);`
- Class structure output (bypassing `__debugInfo()` output, if present): `ref::config('debugInfo', false);`

I am sure many people will appreciate such additional capacity. I hope it helps.