### PR TITLE
PHP8 adaptations

### DIFF
--- a/ref.php
+++ b/ref.php
@@ -39,15 +39,15 @@ function r(){
   foreach($args as $index => $arg)
     $ref->query($arg, $expressions ? $expressions[$index] : null);
 
-  // return the results if this function was called with the error suppression operator 
+  // return the results if this function was called with the error suppression operator
   if($capture)
     return ob_get_clean();
-  
+
   // stop the script if this function was called with the bitwise not operator
   if(in_array('~', $options, true) && ($format === 'html')){
     print '</body></html>';
     exit(0);
-  }  
+  }
 }
 
 
@@ -60,29 +60,29 @@ function r(){
  */
 function rt(){
   $args        = func_get_args();
-  $options     = array();  
+  $options     = array();
   $output      = '';
   $expressions = ref::getInputExpressions($options);
-  $capture     = in_array('@', $options, true);  
-  $ref         = new ref((php_sapi_name() !== 'cli') || $capture ? 'text' : 'cliText');  
+  $capture     = in_array('@', $options, true);
+  $ref         = new ref((php_sapi_name() !== 'cli') || $capture ? 'text' : 'cliText');
 
   if(func_num_args() !== count($expressions))
     $expressions = null;
 
-  if(!headers_sent())    
-    header('Content-Type: text/plain; charset=utf-8');  
+  if(!headers_sent())
+    header('Content-Type: text/plain; charset=utf-8');
 
   if($capture)
-    ob_start();  
+    ob_start();
 
   foreach($args as $index => $arg)
     $ref->query($arg, $expressions ? $expressions[$index] : null);
 
   if($capture)
-    return ob_get_clean(); 
+    return ob_get_clean();
 
   if(in_array('~', $options, true))
-    exit(0);  
+    exit(0);
 }
 
 
@@ -98,23 +98,23 @@ class ref{
   const
 
     MARKER_KEY = '_phpRefArrayMarker_';
-    
+
 
 
   protected static
-  
+
     /**
      * CPU time used for processing
      *
      * @var  array
-     */   
+     */
     $time = 0,
 
     /**
      * Configuration (+ default values)
      *
      * @var  array
-     */     
+     */
     $config = array(
 
                 // initially expanded levels (for HTML mode only)
@@ -132,7 +132,7 @@ class ref{
 
                 // display extra information about resources
                 'showResourceInfo'     => true,
-                
+
                 // display method and parameter list on objects
                 'showMethods'          => true,
 
@@ -148,14 +148,14 @@ class ref{
                 'shortcutFunc'         => array('r', 'rt'),
 
                 // custom/external formatters (as associative array: format => className)
-                'formatters'           => array(),                
+                'formatters'           => array(),
 
                 // stylesheet path (for HTML only);
                 // 'false' means no styles
                 'stylePath'            => '{:dir}/ref.css',
 
                 // javascript path (for HTML only);
-                // 'false' means no js                      
+                // 'false' means no js
                 'scriptPath'           => '{:dir}/ref.js',
 
                 // display url info via cURL
@@ -174,14 +174,14 @@ class ref{
      * used to determine feature support
      *
      * @var  array
-     */ 
+     */
     $env = array(),
 
     /**
      * Timeout point
      *
      * @var  bool
-     */ 
+     */
     $timeout = -1,
 
     $debug = array(
@@ -189,7 +189,7 @@ class ref{
       'objects'   => 0,
       'arrays'    => 0,
       'scalars'   => 0,
-    );    
+    );
 
 
   protected
@@ -198,21 +198,21 @@ class ref{
      * Output formatter of this instance
      *
      * @var  RFormatter
-     */     
+     */
     $fmt = null,
 
     /**
      * Start time of the current instance
      *
      * @var  float
-     */ 
+     */
     $startTime = 0,
 
     /**
      * Internally created objects
      *
      * @var  SplObjectStorage
-     */ 
+     */
     $intObjects = null;
 
 
@@ -257,21 +257,24 @@ class ref{
       'is54'         => version_compare(PHP_VERSION, '5.4') >= 0,
 
       // php 5.4.6+ ?
-      'is546'        => version_compare(PHP_VERSION, '5.4.6') >= 0,      
+      'is546'        => version_compare(PHP_VERSION, '5.4.6') >= 0,
 
       // php 5.6+
-      'is56'         => version_compare(PHP_VERSION, '5.6') >= 0,      
+      'is56'         => version_compare(PHP_VERSION, '5.6') >= 0,
 
       // php 7.0+ ?
-      'is7'          => version_compare(PHP_VERSION, '7.0') >= 0,      
+      'is7'          => version_compare(PHP_VERSION, '7.0') >= 0 && version_compare(PHP_VERSION,       '8.0') < 0,
+
+      // php 8.0+ ?
+      'is8'          => version_compare(PHP_VERSION, '8.0') >= 0,
 
       // curl extension running?
-      'curlActive'   => function_exists('curl_version'),      
+      'curlActive'   => function_exists('curl_version'),
 
       // is the 'mbstring' extension active?
       'mbStr'        => function_exists('mb_detect_encoding'),
 
-      // @see: https://bugs.php.net/bug.php?id=52469     
+      // @see: https://bugs.php.net/bug.php?id=52469
       'supportsDate' => (strncasecmp(PHP_OS, 'WIN', 3) !== 0) || (version_compare(PHP_VERSION, '5.3.10') >= 0),
     );
   }
@@ -297,7 +300,7 @@ class ref{
    */
   public function __set($name, $value){
     throw new \Exception(sprintf('Cannot set %s. Not allowed', $name));
-  }  
+  }
 
 
 
@@ -305,7 +308,7 @@ class ref{
    * Generate structured information about a variable/value/expression (subject)
    *
    * Output is flushed to the screen
-   *   
+   *
    * @param   mixed $subject
    * @param   string $expression
    */
@@ -317,16 +320,16 @@ class ref{
     $this->startTime = microtime(true);
 
     $this->intObjects = new \SplObjectStorage();
-    
+
     $this->fmt->startRoot();
     $this->fmt->startExp();
     $this->evaluateExp($expression);
     $this->fmt->endExp();
-    $this->evaluate($subject);    
+    $this->evaluate($subject);
     $this->fmt->endRoot();
     $this->fmt->flush();
 
-    static::$time += microtime(true) - $this->startTime;     
+    static::$time += microtime(true) - $this->startTime;
   }
 
 
@@ -346,7 +349,7 @@ class ref{
    * @return  double               Elapsed time
    */
   public static function timeFunc($iterations, $function, &$output = null){
-    
+
     $time = 0;
 
     for($i = 0; $i < $iterations; $i++){
@@ -354,7 +357,7 @@ class ref{
       $output = call_user_func($function);
       $time  += microtime(true) - $start;
     }
-    
+
     return round($time, 4);
   }
 
@@ -369,7 +372,7 @@ class ref{
    *
    * Multiple timers can be controlled simultaneously by specifying a timer ID.
    *
-   * @since   1.0   
+   * @since   1.0
    * @param   int $id          Timer ID, optional
    * @param   int $precision   Precision of the result, optional
    * @return  void|double      Elapsed time, or void if the timer was just started
@@ -418,7 +421,7 @@ class ref{
 
       // drop "* "
       if($line !== '')
-        $line = substr($line, 2);      
+        $line = substr($line, 2);
 
       if(strpos($line, '@') !== 0){
 
@@ -435,11 +438,11 @@ class ref{
           $pointer .= "\n{$trimmed}";
           continue;
         }
-        
+
         // tag definitions have not started yet; assume this is part of the description text
-        $description .= "\n{$line}";        
+        $description .= "\n{$line}";
         continue;
-      }  
+      }
 
       $padding = 0;
       $parts = explode(' ', $line, 2);
@@ -471,13 +474,13 @@ class ref{
         $lastIdx = 2;
         if(in_array($parts[1][0], array('&', '$'), true)){
           $line     = ltrim(array_pop($parts));
-          $parts    = array_merge($parts, explode(' ', $line, 2));        
+          $parts    = array_merge($parts, explode(' ', $line, 2));
           $parts[2] = isset($parts[2]) ? ltrim($parts[2]) : null;
         }else{
           $parts[2] = $parts[1];
           $parts[1] = null;
         }
-      }  
+      }
 
       $tags[$tag][] = $parts;
       end($tags[$tag]);
@@ -490,9 +493,9 @@ class ref{
       list($title, $description) = explode("\n\n", $description, 2);
 
     // if we don't have 2 new lines, try to extract first sentence
-    }else{  
+    }else{
       // in order for a sentence to be considered valid,
-      // the next one must start with an uppercase letter    
+      // the next one must start with an uppercase letter
       $sentences = preg_split('/(?<=[.?!])\s+(?=[A-Z])/', $description, 2, PREG_SPLIT_NO_EMPTY);
 
       // failed to detect a second sentence? then assume there's only title and no description text
@@ -518,7 +521,7 @@ class ref{
 
   /**
    * Split a regex into its components
-   * 
+   *
    * Based on "Regex Colorizer" by Steven Levithan (this is a translation from javascript)
    *
    * @link     https://github.com/slevithan/regex-colorizer
@@ -573,24 +576,24 @@ class ref{
 
         if($len === 1){
           switch ($t1) {
-            case 'b': return 8;  
-            case 'f': return 12; 
-            case 'n': return 10; 
-            case 'r': return 13; 
-            case 't': return 9;  
-            case 'v': return 11; 
-            default: return $t1[0]; 
+            case 'b': return 8;
+            case 'f': return 12;
+            case 'n': return 10;
+            case 'r': return 13;
+            case 't': return 9;
+            case 'v': return 11;
+            default: return $t1[0];
           }
         }
       }
 
-      return ($token !== '\\') ? $token[0] : null;  
-    };   
+      return ($token !== '\\') ? $token[0] : null;
+    };
 
     foreach($matches as $m){
 
       if($m[0] === '['){
-        $lastCC         = null;  
+        $lastCC         = null;
         $cLastRangeable = false;
         $cLastType      = 0;  // 0 = none; 1 = range hyphen; 2 = short class
 
@@ -620,7 +623,7 @@ class ref{
 
             }elseif($cm === '\\'){
               throw new \Exception('Incomplete regex token');
-              
+
             }else{
               $output[]       = array('chr-meta' => $cm);
               $cLastRangeable = $cLastType !== 1;
@@ -640,7 +643,7 @@ class ref{
                 $output[]       = array('chr-range' => '-');
                 $cLastRangeable = false;
                 $cLastType      = 1;
-               
+
               }else{
                 $output[] = $closing ? array('chr' => '-') : array('chr-range' => '-');
               }
@@ -663,7 +666,7 @@ class ref{
       }elseif($m[0] === '('){
         if(strlen($m) === 2)
           throw new \Exception('Invalid or unsupported group type');
-   
+
         if(strlen($m) === 1)
           $capturingGroupCount++;
 
@@ -673,7 +676,7 @@ class ref{
         $output[]        = array("g{$groupStyleDepth}" => $m);
 
       }elseif($m[0] === ')'){
-        if(!count($openGroups)) 
+        if(!count($openGroups))
           throw new \Exception('No matching opening parenthesis');
 
         $output[]        = array('g' . $groupStyleDepth => ')');
@@ -686,7 +689,7 @@ class ref{
 
         array_pop($openGroups);
         continue;
-      
+
       }elseif($m[0] === '\\'){
         if(isset($m[1]) && preg_match('/^[1-9]/', $m[1])){
           $nonBackrefDigits = '';
@@ -695,7 +698,7 @@ class ref{
           while($num > $capturingGroupCount){
             preg_match('/[0-9]$/', $num, $digits);
             $nonBackrefDigits = $digits[0] . $nonBackrefDigits;
-            $num = floor($num / 10); 
+            $num = floor($num / 10);
           }
 
           if($num > 0){
@@ -709,7 +712,7 @@ class ref{
           $lastIsQuant = true;
 
         }elseif(isset($m[1]) && preg_match('/^[0bBcdDfnrsStuvwWx]/', $m[1])){
-   
+
           if(preg_match('/^\\\\[cux]$/', $m))
             throw new \Exception('Incomplete regex token');
 
@@ -718,7 +721,7 @@ class ref{
 
         }elseif($m === '\\'){
           throw new \Exception('Incomplete regex token');
-            
+
         }else{
           $output[]    = array('text' => $m);
           $lastIsQuant = true;
@@ -732,10 +735,10 @@ class ref{
 
         if($interval && (+$interval[1] > 65535 || (isset($interval[2]) && (+$interval[2] > 65535))))
           throw new \Exception('Interval quantifier cannot use value over 65,535');
-        
+
         if($interval && isset($interval[2]) && (+$interval[1] > +$interval[2]))
           throw new \Exception('Interval quantifier range is reversed');
-        
+
         $output[]     = array($lastStyle ? $lastStyle : 'meta' => $m);
         $lastIsQuant  = false;
 
@@ -756,14 +759,14 @@ class ref{
       }elseif($m === '.'){
         $output[]    = array('meta' => '.');
         $lastIsQuant = true;
-   
+
       }else{
         $output[]    = array('text' => $m);
         $lastIsQuant = true;
       }
 
       $lastType  = 0;
-      $lastStyle = '';    
+      $lastStyle = '';
     }
 
     if($openGroups)
@@ -799,7 +802,7 @@ class ref{
 
   /**
    * Total CPU time used by the class
-   *   
+   *
    * @param   int precision
    * @return  double
    */
@@ -811,7 +814,7 @@ class ref{
 
   /**
    * Get relevant backtrace info for last ref call
-   *   
+   *
    * @return  array|false
    */
   public static function getBacktrace(){
@@ -843,7 +846,7 @@ class ref{
    * @param   array &$options   Optional, options to gather (from operators)
    * @return  array             Array of string expressions
    */
-  public static function getInputExpressions(array &$options = null){    
+  public static function getInputExpressions(array &$options = null){
 
     // used to determine the position of the current call,
     // if more queries calls were made on the same line
@@ -889,8 +892,8 @@ class ref{
           $j = $i - 1;
           while(isset($tokens[$j]) && is_string($tokens[$j]) && in_array($tokens[$j], array('@', '+', '-', '!', '~')))
             $options[] = $tokens[$j--];
-        }  
-       
+        }
+
         $lvl = $index = $curlies = 0;
         $expressions = array();
 
@@ -908,7 +911,7 @@ class ref{
             $curlies++;
 
           if($token === '}')
-            $curlies--;        
+            $curlies--;
 
           if($token === '(')
             $lvl++;
@@ -921,21 +924,21 @@ class ref{
           if(($curlies < 1) && ($lvl === 0) && ($token === ',')){
             $index++;
             continue;
-          }  
+          }
 
           // negative parentheses count means we reached the end of argument definitions
-          if($lvl < 0){         
+          if($lvl < 0){
             foreach($expressions as &$expression)
               $expression = trim(implode('', $expression));
 
             return $expressions;
           }
 
-          $expressions[$index][] = $token;      
+          $expressions[$index][] = $token;
         }
 
         break;
-      }    
+      }
     }
 
     return array();
@@ -954,7 +957,7 @@ class ref{
     $parents = array($class);
     while(($class = $class->getParentClass()) !== false)
       $parents[] = $class;
-   
+
     return array_reverse($parents);
   }
 
@@ -999,14 +1002,14 @@ class ref{
       if($item->isInternal()){
         $extension = $item->getExtension();
         $meta['title'] = ($extension instanceof \ReflectionExtension) ? sprintf('Internal - part of %s (%s)', $extension->getName(), $extension->getVersion()) : 'Internal';
-      
+
       }else{
-        $comments = static::parseComment($item->getDocComment()); 
+        $comments = static::parseComment($item->getDocComment());
 
         if($comments)
           $meta += $comments;
 
-        $meta['sub'][] = array('Defined in', basename($item->getFileName()) . ':' . $item->getStartLine());        
+        $meta['sub'][] = array('Defined in', basename($item->getFileName()) . ':' . $item->getStartLine());
       }
 
       if(($item instanceof \ReflectionFunction) || ($item instanceof \ReflectionMethod)){
@@ -1019,12 +1022,12 @@ class ref{
             $proto = $item->getPrototype();
             $meta['sub'][] = array('Prototype defined by', $proto->class);
           }catch(\Exception $e){}
-        }  
+        }
 
-        $this->fmt->text('name', $name, $meta, $this->linkify($item));          
+        $this->fmt->text('name', $name, $meta, $this->linkify($item));
         continue;
       }
-      
+
       // @todo: maybe - list interface methods
       if(!($item->isInterface() || (static::$env['is54'] && $item->isTrait()))){
 
@@ -1032,22 +1035,22 @@ class ref{
           $bubbles[] = array('A', 'Abstract');
 
         if(static::$env['is7'] && $item->isAnonymous())
-          $bubbles[] = array('?', 'Anonymous');        
+          $bubbles[] = array('?', 'Anonymous');
 
         if($item->isFinal())
           $bubbles[] = array('F', 'Final');
 
         // php 5.4+ only
         if(static::$env['is54'] && $item->isCloneable())
-          $bubbles[] = array('C', 'Cloneable');          
+          $bubbles[] = array('C', 'Cloneable');
 
         if($item->isIterateable())
-          $bubbles[] = array('X', 'Iterateable');                    
-      
+          $bubbles[] = array('X', 'Iterateable');
+
       }
 
       if($item->isInterface() && $single !== '')
-        $bubbles[] = array('I', 'Interface');                            
+        $bubbles[] = array('I', 'Interface');
 
       if($bubbles)
         $this->fmt->bubbles($bubbles);
@@ -1055,10 +1058,10 @@ class ref{
       if($item->isInterface() && $single === '')
         $name .= sprintf(' (%d)', count($item->getMethods()));
 
-      $this->fmt->text('name', $name, $meta, $this->linkify($item));          
+      $this->fmt->text('name', $name, $meta, $this->linkify($item));
     }
 
-    $this->fmt->cacheLock($hash);  
+    $this->fmt->cacheLock($hash);
   }
 
 
@@ -1089,19 +1092,19 @@ class ref{
       'function'  => $docRefRoot . '/function.%s' . $docRefExt,
       'method'    => $docRefRoot . '/%2$s.%1$s'   . $docRefExt,
       'property'  => $docRefRoot . '/class.%2$s'  . $docRefExt . '#%2$s.props.%1$s',
-      'constant'  => $docRefRoot . '/class.%2$s'  . $docRefExt . '#%2$s.constants.%1$s',      
+      'constant'  => $docRefRoot . '/class.%2$s'  . $docRefExt . '#%2$s.constants.%1$s',
     );
 
-    $url  = null;    
+    $url  = null;
     $args = array();
 
     // determine scheme
     if($constant !== null){
       $type = 'constant';
       $args[] = $constant;
-    
+
     }else{
-      $type = explode('\\', get_class($reflector)); 
+      $type = explode('\\', get_class($reflector));
       $type = strtolower(ltrim(end($type), 'Reflection'));
 
       if($type === 'object')
@@ -1133,7 +1136,7 @@ class ref{
 
     // custom
     }else{
-      switch(true){      
+      switch(true){
 
         // WordPress function;
         // like pretty much everything else in WordPress, API links are inconsistent as well;
@@ -1145,7 +1148,7 @@ class ref{
           }
 
         // @todo: handle more apps
-      }      
+      }
 
     }
 
@@ -1186,14 +1189,14 @@ class ref{
    * @param   bool $specialStr  Should this be interpreted as a special string?
    * @return  mixed             Result (both HTML and text modes generate strings)
    */
-  protected function evaluate(&$subject, $specialStr = false){    
+  protected function evaluate(&$subject, $specialStr = false){
 
     switch($type = gettype($subject)){
 
       // https://github.com/digitalnature/php-ref/issues/13
       case 'unknown type':
         return $this->fmt->text('unknown');
-    
+
       // null value
       case 'NULL':
         return $this->fmt->text('null');
@@ -1213,14 +1216,14 @@ class ref{
 
         // empty array?
         if(empty($subject)){
-          $this->fmt->text('array');          
+          $this->fmt->text('array');
           return $this->fmt->emptyGroup();
-        }  
+        }
 
         if(isset($subject[static::MARKER_KEY])){
           unset($subject[static::MARKER_KEY]);
           $this->fmt->text('array');
-          $this->fmt->emptyGroup('recursion');          
+          $this->fmt->emptyGroup('recursion');
           return;
         }
 
@@ -1236,10 +1239,10 @@ class ref{
 
           // assign new value
           $value = ($value !== 1) ? 1 : 2;
-          
-          // if they're still equal, then we have a reference            
+
+          // if they're still equal, then we have a reference
           if($value === $subject){
-            $value = $buffer;                      
+            $value = $buffer;
             $value[static::MARKER_KEY] = true;
             $this->evaluate($value);
             return;
@@ -1247,18 +1250,18 @@ class ref{
 
           // restoring original value
           $value = $buffer;
-        }        
+        }
 
         $this->fmt->text('array');
         $count = count($subject);
         if(!$this->fmt->startGroup($count))
-          return;               
+          return;
 
         $max = max(array_map('static::strLen', array_keys($subject)));
         $subject[static::MARKER_KEY] = true;
-     
+
         foreach($subject as $key => &$value){
-          
+
           // ignore our temporary marker
           if($key === static::MARKER_KEY)
             continue;
@@ -1295,7 +1298,7 @@ class ref{
       case 'resource':
       case 'resource (closed)':
         $meta    = array();
-        $resType = get_resource_type($subject);        
+        $resType = get_resource_type($subject);
 
         $this->fmt->text('resource', strval($subject));
 
@@ -1320,7 +1323,7 @@ class ref{
           break;
 
           // gd image extension resource
-          case 'gd':            
+          case 'gd':
             $meta = array(
                'size'       => sprintf('%d x %d', imagesx($subject), imagesy($subject)),
                'true_color' => imageistruecolor($subject),
@@ -1364,7 +1367,7 @@ class ref{
 
           // mysql result
           case 'mysql result':
-            while($row = @mysql_fetch_object($subject)){              
+            while($row = @mysql_fetch_object($subject)){
               $meta[] = (array)$row;
 
               if($this->hasInstanceTimedOut())
@@ -1394,26 +1397,26 @@ class ref{
           $this->fmt->colDiv($max - static::strLen($key));
           $this->fmt->sep(':');
           $this->fmt->colDiv();
-          $this->evaluate($value);          
+          $this->evaluate($value);
           $this->fmt->endRow();
         }
         $this->fmt->endGroup();
         return;
 
-      // string      
+      // string
       case 'string':
-        $length   = static::strLen($subject);       
-        $encoding = static::$env['mbStr'] ? mb_detect_encoding($subject) : false;      
+        $length   = static::strLen($subject);
+        $encoding = static::$env['mbStr'] ? mb_detect_encoding($subject) : false;
         $info     = $encoding && ($encoding !== 'ASCII') ? $length . '; ' . $encoding : $length;
 
         if($specialStr){
           $this->fmt->sep('"');
           $this->fmt->text(array('string', 'special'), $subject, "string({$info})");
-          $this->fmt->sep('"');          
+          $this->fmt->sep('"');
           return;
-        }  
-        
-        $this->fmt->text('string', $subject, "string({$info})");        
+        }
+
+        $this->fmt->text('string', $subject, "string({$info})");
 
         // advanced checks only if there are 3 characteres or more
         if(static::$config['showStringMatches'] && ($length > 2) && (trim($subject) !== '')){
@@ -1424,7 +1427,7 @@ class ref{
           // @note: this part of the code is very expensive
           $isFile = ($length < 2048)
             && (max(array_map('strlen', explode('/', str_replace('\\', '/', $subject)))) < 128)
-            && !preg_match('/[^\w\.\-\/\\\\:]|\..*\.|\.$|:(?!(?<=^[a-zA-Z]:)[\/\\\\])/', $subject);            
+            && !preg_match('/[^\w\.\-\/\\\\:]|\..*\.|\.$|:(?!(?<=^[a-zA-Z]:)[\/\\\\])/', $subject);
 
           if($isFile){
             try{
@@ -1434,7 +1437,7 @@ class ref{
 
               if(($perms & 0xC000) === 0xC000)       // socket
                 $flags[] = 's';
-              elseif(($perms & 0xA000) === 0xA000)   // symlink        
+              elseif(($perms & 0xA000) === 0xA000)   // symlink
                 $flags[] = 'l';
               elseif(($perms & 0x8000) === 0x8000)   // regular
                 $flags[] = '-';
@@ -1447,7 +1450,7 @@ class ref{
               elseif(($perms & 0x1000) === 0x1000)   // FIFO pipe
                 $flags[] = 'p';
               else                                   // unknown
-                $flags[] = 'u';        
+                $flags[] = 'u';
 
               // owner
               $flags[] = (($perms & 0x0100) ? 'r' : '-');
@@ -1465,7 +1468,7 @@ class ref{
               $flags[] = (($perms & 0x0001) ? (($perms & 0x0200) ? 't' : 'x' ) : (($perms & 0x0200) ? 'T' : '-'));
 
               $size = is_dir($subject) ? '' : sprintf(' %.2fK', $file->getSize() / 1024);
-              
+
               $this->fmt->startContain('file', true);
               $this->fmt->text('file', implode('', $flags) . $size);
               $this->fmt->endContain();
@@ -1482,19 +1485,19 @@ class ref{
               $this->fmt->startContain('class', true);
               $this->fromReflector(new \ReflectionClass($subject));
               $this->fmt->endContain();
-            }  
+            }
 
             if(!$isClass && interface_exists($subject, false)){
               $this->fmt->startContain('interface', true);
               $this->fromReflector(new \ReflectionClass($subject));
               $this->fmt->endContain('interface');
-            }  
+            }
 
             if(function_exists($subject)){
               $this->fmt->startContain('function', true);
               $this->fromReflector(new \ReflectionFunction($subject));
               $this->fmt->endContain('function');
-            }  
+            }
           }
 
 
@@ -1533,7 +1536,7 @@ class ref{
                   $map = array(
                     'y' => 'yr',
                     'm' => 'mo',
-                    'd' => 'da',                  
+                    'd' => 'da',
                     'h' => 'hr',
                     'i' => 'min',
                     's' => 'sec',
@@ -1557,18 +1560,18 @@ class ref{
                   $this->fmt->startContain('date', true);
                   $this->fmt->text('date', $timeAgo);
                   $this->fmt->endContain();
-                  
-                }  
+
+                }
               }catch(\Exception $e){
                 // not a date
               }
 
             }
 
-            // attempt to detect if this is a serialized string     
+            // attempt to detect if this is a serialized string
             static $unserializing = 0;
             $isSerialized = ($unserializing < 3)
-              && (($subject[$length - 1] === ';') || ($subject[$length - 1] === '}'))              
+              && (($subject[$length - 1] === ';') || ($subject[$length - 1] === '}'))
               && in_array($subject[0], array('s', 'a', 'O'), true)
               && ((($subject[0] === 's') && ($subject[$length - 2] !== '"')) || preg_match("/^{$subject[0]}:[0-9]+:/s", $subject))
               && (($unserialized = @unserialize($subject)) !== false);
@@ -1582,7 +1585,7 @@ class ref{
             }
 
             // try to find out if it's a json-encoded string;
-            // only do this for json-encoded arrays or objects, because other types have too generic formats                
+            // only do this for json-encoded arrays or objects, because other types have too generic formats
             static $decodingJson = 0;
             $isJson = !$isSerialized && ($decodingJson < 3) && in_array($subject[0], array('{', '['), true);
 
@@ -1598,12 +1601,12 @@ class ref{
                 $this->fmt->startContain('json', true);
                 $this->evaluate($data);
                 $this->fmt->endContain();
-              }  
+              }
 
-              $decodingJson--;            
+              $decodingJson--;
             }
 
-            // attempt to match a regex            
+            // attempt to match a regex
             if(!$isSerialized && !$isJson && $length < 768){
               try{
                 $components = $this->splitRegex($subject);
@@ -1614,28 +1617,28 @@ class ref{
                   foreach($components as $component)
                     $this->fmt->text('regex-' . key($component), reset($component));
                   $this->fmt->endContain();
-                }  
+                }
 
               }catch(\Exception $e){
                 // not a regex
               }
 
             }
-          }  
+          }
         }
 
         return;
-    }  
- 
+    }
+
     // if we reached this point, $subject must be an object
 
     // track objects to detect recursion
-    static $hashes = array();      
+    static $hashes = array();
 
     // hash ID of this object
     $hash = spl_object_hash($subject);
     $recursion = isset($hashes[$hash]);
- 
+
     // sometimes incomplete objects may be created from string unserialization,
     // if the class to which the object belongs wasn't included until the unserialization stage...
     if($subject instanceof \__PHP_Incomplete_Class){
@@ -1647,9 +1650,9 @@ class ref{
     // check cache at this point
     if(!$recursion && $this->fmt->didCache($hash)){
       static::$debug['cacheHits']++;
-      return;        
+      return;
     }
-  
+
     $reflector = new \ReflectionObject($subject);
     $this->fmt->startContain('class');
     $this->fromReflector($reflector);
@@ -1667,7 +1670,7 @@ class ref{
     if(static::$config['showPrivateMembers'])
       $flags |= \ReflectionProperty::IS_PRIVATE;
 
-    $props = $magicProps = $methods = array();    
+    $props = $magicProps = $methods = array();
 
     if($reflector->hasMethod('__debugInfo')){
       $magicProps = $subject->__debugInfo();
@@ -1679,7 +1682,7 @@ class ref{
       $flags = \ReflectionMethod::IS_PUBLIC | \ReflectionMethod::IS_PROTECTED;
 
       if(static::$config['showPrivateMembers'])
-        $flags |= \ReflectionMethod::IS_PRIVATE;          
+        $flags |= \ReflectionMethod::IS_PRIVATE;
 
       $methods = $reflector->getMethods($flags);
     }
@@ -1687,17 +1690,17 @@ class ref{
     $constants  = $reflector->getConstants();
     $interfaces = $reflector->getInterfaces();
     $traits     = static::$env['is54'] ? $reflector->getTraits() : array();
-    $parents    = static::getParentClasses($reflector);        
+    $parents    = static::getParentClasses($reflector);
 
     // work-around for https://bugs.php.net/bug.php?id=49154
     // @see http://stackoverflow.com/questions/15672287/strange-behavior-of-reflectiongetproperties-with-numeric-keys
-    if(!static::$env['is54']){      
+    if(!static::$env['is54']){
       $props = array_values(array_filter($props, function($prop) use($subject){
         return !$prop->isPublic() || property_exists($subject, $prop->name);
       }));
     }
-    
-    // no data to display?        
+
+    // no data to display?
     if(!$props && !$methods && !$constants && !$interfaces && !$traits){
       unset($hashes[$hash]);
       return $this->fmt->emptyGroup();
@@ -1710,15 +1713,15 @@ class ref{
     if(static::$config['showIteratorContents'] && $reflector->isIterateable()){
 
       $itContents = iterator_to_array($subject);
-      $this->fmt->sectionTitle(sprintf('Contents (%d)', count($itContents)));          
+      $this->fmt->sectionTitle(sprintf('Contents (%d)', count($itContents)));
 
       foreach($itContents as $key => $value){
         $keyInfo = gettype($key);
         if($keyInfo === 'string'){
           $encoding = static::$env['mbStr'] ? mb_detect_encoding($key) : '';
           $length   = $encoding && ($encoding !== 'ASCII') ? static::strLen($key) . '; ' . $encoding : static::strLen($key);
-          $keyInfo  = sprintf('%s(%s)', $keyInfo, $length);        
-        }            
+          $keyInfo  = sprintf('%s(%s)', $keyInfo, $length);
+        }
 
         $this->fmt->startRow();
         $this->fmt->text(array('key', 'iterator'), $key, sprintf('Iterator key: %s', $keyInfo));
@@ -1729,14 +1732,14 @@ class ref{
         //$this->evaluate($value instanceof \Traversable ? ((count($value) > 0) ? $value : (string)$value) : $value);
         $this->fmt->endRow();
       }
-    }        
+    }
 
     // display the interfaces this objects' class implements
     if($interfaces){
-      $items = array();            
+      $items = array();
       $this->fmt->sectionTitle('Implements');
       $this->fmt->startRow();
-      $this->fmt->startContain('interfaces');          
+      $this->fmt->startContain('interfaces');
 
       $i     = 0;
       $count = count($interfaces);
@@ -1746,31 +1749,31 @@ class ref{
 
         if(++$i < $count)
           $this->fmt->sep(', ');
-      }  
+      }
 
-      $this->fmt->endContain();          
+      $this->fmt->endContain();
       $this->fmt->endRow();
-    } 
+    }
 
     // traits this objects' class uses
-    if($traits){       
-      $items = array();      
+    if($traits){
+      $items = array();
       $this->fmt->sectionTitle('Uses');
       $this->fmt->startRow();
-      $this->fmt->startContain('traits');            
+      $this->fmt->startContain('traits');
 
       $i     = 0;
-      $count = count($traits);          
+      $count = count($traits);
 
       foreach($traits as $name => $trait){
         $this->fromReflector($trait);
-        
-        if(++$i < $count)  
-          $this->fmt->sep(', ');                      
-      }  
+
+        if(++$i < $count)
+          $this->fmt->sep(', ');
+      }
 
       $this->fmt->endContain();
-      $this->fmt->endRow();             
+      $this->fmt->endRow();
     }
 
     // class constants
@@ -1778,35 +1781,35 @@ class ref{
       $this->fmt->sectionTitle('Constants');
       $max = max(array_map('static::strLen', array_keys($constants)));
       foreach($constants as $name => $value){
-        $meta = null;              
+        $meta = null;
         $type = array('const');
         foreach($parents as $parent){
           if($parent->hasConstant($name)){
             if($parent !== $reflector){
               $type[] = 'inherited';
               $meta = array('sub' => array(array('Prototype defined by', $parent->name)));
-            }  
+            }
             break;
           }
         }
 
         $this->fmt->startRow();
-        $this->fmt->sep('::');  
+        $this->fmt->sep('::');
         $this->fmt->colDiv();
         $this->fmt->startContain($type);
         $this->fmt->text('name', $name, $meta, $this->linkify($parent, $name));
         $this->fmt->endContain();
-        $this->fmt->colDiv($max - static::strLen($name));        
+        $this->fmt->colDiv($max - static::strLen($name));
         $this->fmt->sep('=');
         $this->fmt->colDiv();
-        $this->evaluate($value);          
+        $this->evaluate($value);
         $this->fmt->endRow();
-      }    
+      }
     }
 
     // object/class properties
     if($props){
-      $this->fmt->sectionTitle('Properties');        
+      $this->fmt->sectionTitle('Properties');
 
       $max = 0;
       foreach($props as $idx => $prop)
@@ -1830,10 +1833,10 @@ class ref{
           if(isset($meta['tags']['var'][0]))
             $meta['left'] = $meta['tags']['var'][0][0];
 
-          unset($meta['tags']);        
+          unset($meta['tags']);
         }
 
-        if($prop->isProtected() || $prop->isPrivate())        
+        if($prop->isProtected() || $prop->isPrivate())
           $prop->setAccessible(true);
 
         $value = $prop->getValue($subject);
@@ -1869,7 +1872,7 @@ class ref{
         $this->evaluate($value);
         $this->fmt->endRow();
       }
-    }    
+    }
 
     // __debugInfo()
     if($magicProps){
@@ -1907,20 +1910,20 @@ class ref{
         $this->fmt->sep('=');
         $this->fmt->colDiv();
         $this->evaluate($value);
-        $this->fmt->endRow();        
+        $this->fmt->endRow();
       }
-    }      
+    }
 
     // class methods
     if($methods && !$this->hasInstanceTimedOut()){
 
-      $this->fmt->sectionTitle('Methods');  
+      $this->fmt->sectionTitle('Methods');
       foreach($methods as $idx => $method){
 
         $this->fmt->startRow();
         $this->fmt->sep($method->isStatic() ? '::' : '->');
         $this->fmt->colDiv();
-        
+
         $bubbles = array();
         if($method->isAbstract())
           $bubbles[] = array('A', 'Abstract');
@@ -1935,7 +1938,7 @@ class ref{
           $bubbles[] = array('!', 'Private');
 
         $this->fmt->bubbles($bubbles);
-         
+
         $this->fmt->colDiv(4 - count($bubbles));
 
         // is this method inherited?
@@ -1953,9 +1956,9 @@ class ref{
 
         $name = $method->name;
         if($method->returnsReference())
-          $name = "&{$name}";    
+          $name = "&{$name}";
 
-        $this->fromReflector($method, $name, $reflector); 
+        $this->fromReflector($method, $name, $reflector);
 
         $paramCom   = $method->isInternal() ? array() : static::parseComment($method->getDocComment(), 'tags');
         $paramCom   = empty($paramCom['param']) ? array() : $paramCom['param'];
@@ -1981,8 +1984,8 @@ class ref{
           if($optional)
             $type[] = 'optional';
 
-          $this->fmt->startContain($type);            
-          
+          $this->fmt->startContain($type);
+
           // attempt to build meta
           foreach($paramCom as $tag){
             list($pcTypes, $pcName, $pcDescription) = $tag;
@@ -1996,9 +1999,15 @@ class ref{
 
             break;
           }
-       
+
           try{
-            $paramClass = $parameter->getClass();
+            if(static::$env['is8']){
+              $paramClass = $parameter->getType() && !$parameter->getType()->isBuiltin()
+                ? new ReflectionClass($parameter->getType()->getName())
+                : null;
+            }else{
+              $paramClass = $parameter->getClass();
+            }
           }catch(\Exception $e){
             // @see https://bugs.php.net/bug.php?id=32177&edit=1
           }
@@ -2008,11 +2017,9 @@ class ref{
             $this->fromReflector($paramClass, $paramClass->name);
             $this->fmt->endContain();
             $this->fmt->sep(' ');
-          
-          }elseif($parameter->isArray()){
+          }elseif((static::$env['is8'] && $parameter->getType() && $parameter->getType()->getName() === 'array') || (static::$env['is7'] && $parameter->isArray())) {
             $this->fmt->text('hint', 'array');
-            $this->fmt->sep(' ');            
-
+            $this->fmt->sep(' ');
           }else{
             $hasType = static::$env['is7'] && $parameter->hasType();
             if($hasType){
@@ -2063,7 +2070,7 @@ class ref{
 
         $this->fmt->endRow();
       }
-    }  
+    }
 
     unset($hashes[$hash]);
     $this->fmt->endGroup();
@@ -2100,31 +2107,31 @@ class ref{
     try{
       $reflector = new \ReflectionFunction($keywords[0]);
       $parts[] = array($keywords[0], $reflector, '');
-    
+
     }catch(\Exception $e){
 
       if(stripos($keywords[0], 'new ') === 0){
         $cn = explode(' ' , $keywords[0], 2);
 
         // linkify 'new keyword' (as constructor)
-        try{          
+        try{
           $reflector = new \ReflectionMethod($cn[1], '__construct');
           $parts[] = array($cn[0], $reflector, '');
 
         }catch(\Exception $e){
           $reflector = null;
           $parts[] = $cn[0];
-        }            
+        }
 
         // class name...
-        try{          
+        try{
           $reflector = new \ReflectionClass($cn[1]);
           $parts[] = array($cn[1], $reflector, ' ');
 
         }catch(\Exception $e){
           $reflector = null;
           $parts[] = $cn[1];
-        }      
+        }
 
       }else{
 
@@ -2142,7 +2149,7 @@ class ref{
         }catch(\Exception $e){
           $reflector = null;
           $parts[] = $cn[0];
-        }        
+        }
 
         // perhaps it's a static class method; try to linkify method
         try{
@@ -2152,11 +2159,11 @@ class ref{
         }catch(\Exception $e){
           $reflector = null;
           $parts[] = $cn[1];
-        }              
+        }
       }
     }
 
-    $parts[] = "({$keywords[1]}";    
+    $parts[] = "({$keywords[1]}";
 
     foreach($parts as $element){
       if(!is_array($element)){
@@ -2167,11 +2174,11 @@ class ref{
       list($text, $reflector, $prefix) = $element;
 
       if($prefix !== '')
-        $this->fmt->text('expTxt', $prefix);      
+        $this->fmt->text('expTxt', $prefix);
 
       $this->fromReflector($reflector, $text);
     }
-  
+
   }
 
 
@@ -2183,7 +2190,7 @@ class ref{
    * @return  int
    */
   protected static function strLen($string){
-    $encoding = function_exists('mb_detect_encoding') ? mb_detect_encoding($string) : false;   
+    $encoding = function_exists('mb_detect_encoding') ? mb_detect_encoding($string) : false;
     return $encoding ? mb_strlen($string, $encoding) : strlen($string);
   }
 
@@ -2209,12 +2216,12 @@ class ref{
 
 /**
  * Formatter abstraction
- */ 
+ */
 abstract class RFormatter{
 
   /**
    * Flush output and send contents to the output device
-   */ 
+   */
   abstract public function flush();
 
   /**
@@ -2224,7 +2231,7 @@ abstract class RFormatter{
    * @param  string|null $text
    * @param  string|array|null $meta
    * @param  string|null $uri
-   */ 
+   */
   abstract public function text($type, $text = null, $meta = null, $uri = null);
 
   /**
@@ -2232,19 +2239,19 @@ abstract class RFormatter{
    *
    * @param  string|array $type
    * @param  string|bool $label
-   */ 
+   */
   public function startContain($type, $label = false){}
 
   /**
    * Generate container ending token
-   */ 
-  public function endContain(){}  
+   */
+  public function endContain(){}
 
   /**
    * Generate empty group token
    *
    * @param  string $prefix
-   */ 
+   */
   public function emptyGroup($prefix = ''){}
 
   /**
@@ -2255,63 +2262,63 @@ abstract class RFormatter{
    *
    * @param   string $prefix
    * @return  bool
-   */ 
+   */
   public function startGroup($prefix = ''){}
 
   /**
-   * Generate group ending token   
-   */ 
+   * Generate group ending token
+   */
   public function endGroup(){}
 
   /**
    * Generate section title
    *
    * @param  string $title
-   */ 
+   */
   public function sectionTitle($title){}
 
   /**
    * Generate row start token
-   */ 
+   */
   public function startRow(){}
 
   /**
    * Generate row ending token
-   */ 
+   */
   public function endRow(){}
 
   /**
    * Column divider (cell delimiter)
    *
    * @param  int $padLen
-   */ 
+   */
   public function colDiv($padLen = null){}
 
   /**
    * Generate modifier tokens
    *
    * @param  array $items
-   */ 
+   */
   public function bubbles(array $items){}
 
   /**
    * Input expression start
-   */ 
+   */
   public function startExp(){}
 
   /**
    * Input expression end
-   */ 
+   */
   public function endExp(){}
 
   /**
    * Root starting token
-   */ 
+   */
   public function startRoot(){}
 
   /**
    * Root ending token
-   */ 
+   */
   public function endRoot(){}
 
   /**
@@ -2319,7 +2326,7 @@ abstract class RFormatter{
    *
    * @param  string $label
    */
-  public function sep($label = ' '){}  
+  public function sep($label = ' '){}
 
   /**
    * Resolve cache request
@@ -2332,7 +2339,7 @@ abstract class RFormatter{
    *
    * @param   string $id
    * @return  bool
-   */ 
+   */
   public function didCache($id){
     return false;
   }
@@ -2341,7 +2348,7 @@ abstract class RFormatter{
    * Ends cache capturing for the given ID
    *
    * @param  string $id
-   */ 
+   */
   public function cacheLock($id){}
 
 }
@@ -2351,7 +2358,7 @@ abstract class RFormatter{
 
 /**
  * Generates the output in HTML5 format
- *   
+ *
  */
 class RHtmlFormatter extends RFormatter{
 
@@ -2361,25 +2368,25 @@ class RHtmlFormatter extends RFormatter{
      * Actual output
      *
      * @var  string
-     */  
+     */
     $out = '',
 
     /**
      * Tracks current nesting level
      *
      * @var  int
-     */  
+     */
     $level = 0,
-     
+
     /**
      * Stores tooltip content for all entries
      *
      * To avoid having duplicate tooltip data in the HTML, we generate them once,
-     * and use references (the Q index) to pull data when required; 
-     * this improves performance significantly 
+     * and use references (the Q index) to pull data when required;
+     * this improves performance significantly
      *
      * @var  array
-     */     
+     */
     $tips = array(),
 
     /**
@@ -2389,7 +2396,7 @@ class RHtmlFormatter extends RFormatter{
      * Cached objects will not be processed again in the same query
      *
      * @var  array
-     */ 
+     */
     $cache = array(),
 
     /**
@@ -2407,14 +2414,14 @@ class RHtmlFormatter extends RFormatter{
      * Instance counter
      *
      * @var  int
-     */   
+     */
     $counter = 0,
 
     /**
      * Tracks style/jscript inclusion state
      *
      * @var  bool
-     */    
+     */
     $didAssets = false;
 
 
@@ -2441,8 +2448,8 @@ class RHtmlFormatter extends RFormatter{
         'base'   => 'r',
         'tip'    => 't',
         'cell'   => 'c',
-        'table'  => 't',        
-        'row'    => 'r',        
+        'table'  => 't',
+        'row'    => 'r',
         'group'  => 'g',
         'gLabel' => 'gl',
         'match'  => 'm',
@@ -2467,7 +2474,7 @@ class RHtmlFormatter extends RFormatter{
 
     if(!isset($this->cache[$id])){
       $this->cache[$id] = array();
-      $this->cache[$id][] = strlen($this->out);     
+      $this->cache[$id][] = strlen($this->out);
       return false;
     }
 
@@ -2479,7 +2486,7 @@ class RHtmlFormatter extends RFormatter{
     $this->out .= substr($this->out, $this->cache[$id][0], $this->cache[$id][1]);
     return true;
   }
-  
+
   public function cacheLock($id){
     $this->cache[$id][] = strlen($this->out) - $this->cache[$id][0];
   }
@@ -2487,7 +2494,7 @@ class RHtmlFormatter extends RFormatter{
 
   public function sep($label = ' '){
     $this->out .= $label !== ' ' ? '<i>' . static::escape($label) . '</i>' : $label;
-  }  
+  }
 
   public function text($type, $text = null, $meta = null, $uri = null){
 
@@ -2495,7 +2502,7 @@ class RHtmlFormatter extends RFormatter{
       $type = (array)$type;
 
     $tip  = '';
-    $text = ($text !== null) ? static::escape($text) : static::escape($type[0]);    
+    $text = ($text !== null) ? static::escape($text) : static::escape($type[0]);
 
     if(in_array('special', $type)){
       $text = strtr($text, array(
@@ -2510,13 +2517,13 @@ class RHtmlFormatter extends RFormatter{
     }
 
     // generate tooltip reference (probably the slowest part of the code ;)
-    if($meta !== null){       
+    if($meta !== null){
       $tipIdx = array_search($meta, $this->tips, true);
 
       if($tipIdx === false)
         $tipIdx = array_push($this->tips, $meta) - 1;
 
-      $tip = " {$this->def['tipRef']}=\"{$tipIdx}\"";      
+      $tip = " {$this->def['tipRef']}=\"{$tipIdx}\"";
       //$tip = sprintf('%s="%d"', $this->def['tipRef'], $tipIdx);
     }
 
@@ -2528,14 +2535,14 @@ class RHtmlFormatter extends RFormatter{
     foreach($type as $part)
       $typeStr .= " data-{$part}";
 
-    $this->out .= "<{$this->def['base']}{$typeStr}{$tip}>{$text}</{$this->def['base']}>";    
+    $this->out .= "<{$this->def['base']}{$typeStr}{$tip}>{$text}</{$this->def['base']}>";
     //$this->out .= sprintf('<%1$s%2$s %3$s>%4$s</%1$s>', $this->def['base'], $typeStr, $tip, $text);
   }
 
   public function startContain($type, $label = false){
 
     if(!is_array($type))
-      $type = (array)$type;    
+      $type = (array)$type;
 
     if($label)
       $this->out .= '<br>';
@@ -2548,19 +2555,19 @@ class RHtmlFormatter extends RFormatter{
 
     if($label)
       $this->out .= "<{$this->def['base']} {$this->def['match']}>{$type[0]}</{$this->def['base']}>";
-  }    
+  }
 
   public function endContain(){
     $this->out .= "</{$this->def['base']}>";
-  } 
+  }
 
   public function emptyGroup($prefix = ''){
 
     if($prefix !== '')
       $prefix = "<{$this->def['base']} {$this->def['gLabel']}>" . static::escape($prefix) . "</{$this->def['base']}>";
-    
+
     $this->out .= "<i>(</i>{$prefix}<i>)</i>";
-  }    
+  }
 
 
   public function startGroup($prefix = ''){
@@ -2568,18 +2575,18 @@ class RHtmlFormatter extends RFormatter{
     $maxDepth = ref::config('maxDepth');
 
     if(($maxDepth > 0) && (($this->level + 1) > $maxDepth)){
-      $this->emptyGroup('...');   
+      $this->emptyGroup('...');
       return false;
-    }   
+    }
 
     $this->level++;
 
     $expLvl = ref::config('expLvl');
     $exp = ($expLvl < 0) || (($expLvl > 0) && ($this->level <= $expLvl)) ? ' data-exp' : '';
-    
+
     if($prefix !== '')
       $prefix = "<{$this->def['base']} {$this->def['gLabel']}>" . static::escape($prefix) . "</{$this->def['base']}>";
-   
+
     $this->out .= "<i>(</i>{$prefix}<{$this->def['base']} data-toggle{$exp}></{$this->def['base']}><{$this->def['base']} {$this->def['group']}><{$this->def['base']} {$this->def['table']}>";
 
     return true;
@@ -2589,39 +2596,39 @@ class RHtmlFormatter extends RFormatter{
     $this->out .= "</{$this->def['base']}></{$this->def['base']}><i>)</i>";
     $this->level--;
   }
- 
+
   public function sectionTitle($title){
     $this->out .= "</{$this->def['base']}><{$this->def['base']} data-tHead>{$title}</{$this->def['base']}><{$this->def['base']} {$this->def['table']}>";
   }
 
   public function startRow(){
     $this->out .= "<{$this->def['base']} {$this->def['row']}><{$this->def['base']} {$this->def['cell']}>";
-  } 
+  }
 
   public function endRow(){
     $this->out .= "</{$this->def['base']}></{$this->def['base']}>";
-  } 
-     
+  }
+
   public function colDiv($padLen = null){
     $this->out .= "</{$this->def['base']}><{$this->def['base']} {$this->def['cell']}>";
-  }   
+  }
 
   public function bubbles(array $items){
 
     if(!$items)
       return;
 
-    $this->out .= "<{$this->def['base']} data-mod>";   
+    $this->out .= "<{$this->def['base']} data-mod>";
 
     foreach($items as $info)
       $this->out .= $this->text('mod-' . strtolower($info[1]), $info[0], $info[1]);
 
     $this->out .= "</{$this->def['base']}>";
-  }      
-      
+  }
+
   public function startExp(){
     $this->out .= "<{$this->def['base']} data-input>";
-  }                    
+  }
 
   public function endExp(){
     if(ref::config('showBacktrace') && ($trace = ref::getBacktrace())){
@@ -2631,11 +2638,11 @@ class RHtmlFormatter extends RFormatter{
     }
 
     $this->out .= "</{$this->def['base']}><{$this->def['base']} data-output>";
-  } 
+  }
 
   public function startRoot(){
     $this->out .= '<!-- ref#' . ++static::$counter . ' --><div>' . static::getAssets() . '<div class="ref">';
-  }                    
+  }
 
   public function endRoot(){
     $this->out .= "</{$this->def['base']}>";
@@ -2653,7 +2660,7 @@ class RHtmlFormatter extends RFormatter{
         'left'        => '',
         'description' => '',
         'tags'        => array(),
-        'sub'         => array(),            
+        'sub'         => array(),
       );
 
       $meta = static::escape($meta);
@@ -2690,7 +2697,7 @@ class RHtmlFormatter extends RFormatter{
       $sub = '';
       foreach($meta['sub'] as $line)
         $sub .= "<{$this->def['base']} {$this->def['row']}><{$this->def['base']} {$this->def['cell']}>" . implode("</{$this->def['base']}><{$this->def['base']} {$this->def['cell']}>", $line) . "</{$this->def['base']}></{$this->def['base']}>";
-    
+
       if($sub)
         $tip .= "<{$this->def['base']} {$this->def['row']}><{$this->def['base']} {$this->def['cell']} data-sub><{$this->def['base']} {$this->def['table']}>{$sub}</{$this->def['base']}></{$this->def['base']}></{$this->def['base']}>";
 
@@ -2701,7 +2708,7 @@ class RHtmlFormatter extends RFormatter{
     if(($timeout = ref::getTimeoutPoint()) > 0)
       $this->out .= sprintf("<{$this->def['base']} data-error>Listing incomplete. Timed-out after %4.2fs</{$this->def['base']}>", $timeout);
 
-    $this->out .= '</div></div><!-- /ref#' . static::$counter . ' -->';        
+    $this->out .= '</div></div><!-- /ref#' . static::$counter . ' -->';
   }
 
 
@@ -2712,10 +2719,10 @@ class RHtmlFormatter extends RFormatter{
    * @return  string
    */
   public static function getAssets(){
-    
+
     // first call? include styles and javascript
     if(static::$didAssets)
-      return '';   
+      return '';
 
     ob_start();
 
@@ -2733,7 +2740,7 @@ class RHtmlFormatter extends RFormatter{
         <?php readfile(str_replace('{:dir}', __DIR__, ref::config('scriptPath'))); ?>
       </script>
       <?php
-    }  
+    }
 
     // normalize space and remove comments
     $output = preg_replace('/\s+/', ' ', trim(ob_get_clean()));
@@ -2761,7 +2768,7 @@ class RHtmlFormatter extends RFormatter{
 
 /**
  * Generates the output in plain text format
- *   
+ *
  */
 class RTextFormatter extends RFormatter{
 
@@ -2771,21 +2778,21 @@ class RTextFormatter extends RFormatter{
      * Actual output
      *
      * @var  string
-     */  
+     */
     $out        = '',
 
     /**
      * Tracks current nesting level
      *
      * @var  int
-     */  
-    $level      = 0,    
+     */
+    $level      = 0,
 
     /**
      * Current indenting level
      *
      * @var  int
-     */ 
+     */
     $indent     = 0,
 
     $lastIdx    = 0,
@@ -2795,14 +2802,14 @@ class RTextFormatter extends RFormatter{
 
 
   public function flush(){
-    print $this->out;    
+    print $this->out;
     $this->out   = '';
     $this->cache = array();
   }
 
   public function sep($label = ' '){
     $this->out .= $label;
-  }  
+  }
 
   public function text($type, $text = null, $meta = null, $uri = null){
 
@@ -2825,7 +2832,7 @@ class RTextFormatter extends RFormatter{
 
       $this->out .= $text;
       return;
-    }        
+    }
 
     $formatMap = array(
       'string'   => '%3$s "%2$s"',
@@ -2845,27 +2852,27 @@ class RTextFormatter extends RFormatter{
   public function startContain($type, $label = false){
 
     if(!is_array($type))
-      $type = (array)$type;   
+      $type = (array)$type;
 
     if($label)
       $this->out .= "\n" . str_repeat(' ', $this->indent + $this->levelPad[$this->level]) . "┗ {$type[0]} ~ ";
-  }    
+  }
 
   public function emptyGroup($prefix = ''){
     $this->out .= "({$prefix})";
-  }    
+  }
 
   public function startGroup($prefix = ''){
 
     $maxDepth = ref::config('maxDepth');
 
     if(($maxDepth > 0) && (($this->level + 1) > $maxDepth)){
-      $this->emptyGroup('...');              
+      $this->emptyGroup('...');
       return false;
     }
 
-    $this->level++;  
-    $this->out .= '(';  
+    $this->level++;
+    $this->out .= '(';
 
     $this->indent += $this->levelPad[$this->level - 1];
     return true;
@@ -2885,20 +2892,20 @@ class RTextFormatter extends RFormatter{
   public function startRow(){
     $this->out .= "\n  " . str_repeat(' ', $this->indent);
     $this->lastLineSt = strlen($this->out);
-  } 
+  }
 
   public function endRow(){
-  } 
-     
+  }
+
   public function colDiv($padLen = null){
     $padLen = ($padLen !== null) ? $padLen + 1 : 1;
     $this->out .= str_repeat(' ', $padLen);
 
     $this->lastIdx = strlen($this->out);
-    $this->levelPad[$this->level] = $this->lastIdx - $this->lastLineSt + 2;     
-  }   
+    $this->levelPad[$this->level] = $this->lastIdx - $this->lastLineSt + 2;
+  }
 
-  public function bubbles(array $items){    
+  public function bubbles(array $items){
 
     if(!$items){
       $this->out .= '  ';
@@ -2911,7 +2918,7 @@ class RTextFormatter extends RFormatter{
       $this->out .= $item[0];
 
     $this->out .= '>';
-  }      
+  }
 
   public function endExp(){
 
@@ -2919,17 +2926,17 @@ class RTextFormatter extends RFormatter{
       $this->out .= ' - ' . $trace['file'] . ':' . $trace['line'];
 
     $this->out .= "\n" . str_repeat('=', strlen($this->out)) . "\n";
-  }                    
- 
+  }
+
   public function startRoot(){
     $this->out .= "\n\n";
 
-  }                    
+  }
 
   public function endRoot(){
-    $this->out .= "\n"; 
+    $this->out .= "\n";
     if(($timeout = ref::getTimeoutPoint()) > 0)
-      $this->out .= sprintf("\n-- Listing incomplete. Timed-out after %4.2fs -- \n", $timeout);    
+      $this->out .= sprintf("\n-- Listing incomplete. Timed-out after %4.2fs -- \n", $timeout);
   }
 
 }
@@ -2938,30 +2945,30 @@ class RTextFormatter extends RFormatter{
 
 /**
  * Text formatter with color support for CLI -- unfinished
- *   
+ *
  */
 class RCliTextFormatter extends RTextFormatter{
 
   public function sectionTitle($title){
     $pad = str_repeat(' ', $this->indent + 2);
-    $this->out .= sprintf("\n\n%s\x1b[4;97m%s\x1b[0m", $pad, $title);    
+    $this->out .= sprintf("\n\n%s\x1b[4;97m%s\x1b[0m", $pad, $title);
   }
 
   public function startExp(){
     $this->out .= "\x1b[1;44;96m ";
-  }                    
+  }
 
   public function endExp(){
     if(ref::config('showBacktrace') && ($trace = ref::getBacktrace()))
       $this->out .= "\x1b[0m\x1b[44;36m " . $trace['file'] . ':' . $trace['line'];
 
     $this->out .=  " \x1b[0m\n";
-  }                                 
+  }
 
   public function endRoot(){
-    $this->out .= "\n"; 
+    $this->out .= "\n";
     if(($timeout = ref::getTimeoutPoint()) > 0)
-      $this->out .= sprintf("\n\x1b[3;91m-- Listing incomplete. Timed-out after %4.2fs --\x1b[0m\n", $timeout);    
+      $this->out .= sprintf("\n\x1b[3;91m-- Listing incomplete. Timed-out after %4.2fs --\x1b[0m\n", $timeout);
   }
 
 }


### PR DESCRIPTION
Depending of which PHP version is running, a slightly different code is executed in order to adapt the code to the deprecations of `ReflectionParameter::isArray()` and `ReflecionParameter::getClass()`.

I've based the modifications on the suggestions in [this article on PHP.Watch](https://php.watch/versions/8.0/deprecated-reflectionparameter-methods)

I've modified the `is7` key because I need it to refer to PHP 7 only. The way it was implemented before, although I'm on PHP 8, it keeps returning `1`. So now it checks if the current version is higher than 7 but lower than 8. I've also created an `is8` key just to check if the current version is equals or higher than 8. The resulting code should be retrocompatible.

P.S.: Sorry for the trailing whitespaces deletions 😅